### PR TITLE
Add CLI option `--version` to show version info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Added
+  - A command line option `--version` to show the current version of pydoclint
+
 ## [0.0.7] - 2023-06-01
 
 - Fixed

--- a/pydoclint/__init__.py
+++ b/pydoclint/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version('pydoclint')

--- a/pydoclint/main.py
+++ b/pydoclint/main.py
@@ -5,12 +5,12 @@ from typing import Dict, List, Optional, Tuple
 
 import click
 
+from pydoclint import __version__
 from pydoclint.parse_config import (
     injectDefaultOptionsFromUserSpecifiedTomlFilePath,
 )
 from pydoclint.utils.violation import Violation
 from pydoclint.visitor import Visitor
-from pydoclint import __version__
 
 
 def validateStyleValue(

--- a/pydoclint/main.py
+++ b/pydoclint/main.py
@@ -10,6 +10,7 @@ from pydoclint.parse_config import (
 )
 from pydoclint.utils.violation import Violation
 from pydoclint.visitor import Visitor
+from pydoclint import __version__
 
 
 def validateStyleValue(
@@ -142,6 +143,7 @@ def validateStyleValue(
         ' over the .toml file'
     ),
 )
+@click.version_option(__version__)
 @click.pass_context
 def main(  # noqa: C901
         ctx: click.Context,


### PR DESCRIPTION
A version info command line flag helps, especially with a project in such rapid development to be sure about which version is currently used.

This pull request adds a `__version__` attribute to the package and a `--version` option to the cli program. The version info is taken from `setup.cfg`.