### PR TITLE
✨ Add ability to use as stand-alone pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,8 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+
+  - repo: https://github.com/pre-commit/pre-commit
+    rev: v3.2.2
+    hooks:
+      - id: validate_manifest

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: pydoclint
     name: pydoclint
-    description: 'A Python docstring linter matching signatures.'
+    description: 'A Python docstring linter that checks arguments, returns, yields, and raises sections'
     entry: pydoclint
     language: python
     types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: pydoclint
+    name: pydoclint
+    description: 'A Python docstring linter matching signatures.'
+    entry: pydoclint
+    language: python
+    types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added
   - A command line option `--version` to show the current version of pydoclint
+  - Enabled pydoclint to be used as a pre-commit hook
 
 ## [0.0.7] - 2023-06-01
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ set up as a hook with the following `.pre-commit-config.yaml` configuration:
 
 You will need to install `pre-commit` and run `pre-commit install`.
 
-### 2.5. Native vs _flake8_
+### 2.4. Native vs _flake8_
 
 Should I use _pydoclint_ as a native command line tool or a _flake8_ plugin?
 Here's comparison:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ set up as a hook with the following `.pre-commit-config.yaml` configuration:
   rev: 0.0.7
   hooks:
     - id: pydoclint
+      args:
+        - "--config=pyproject.toml"
 ```
 
 You will need to install `pre-commit` and run `pre-commit install`.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,22 @@ flake8 --select=DOC <FILE_OR_FOLDER>
 If you don't include `--select=DOC` in your command, _flake8_ will also run
 other built-in _flake8_ linters on your code.
 
-### 2.3. Native vs _flake8_
+### 2.3. As a pre-commit hook
+
+`pydoclint` is configured for [pre-commit](https://pre-commit.com/)
+and can be set up as a hook with the following `.pre-commit-config.yaml`
+configuration:
+
+```yaml
+- repo: https://github.com/jsh9/pydoclint
+  rev: 0.0.7
+  hooks:
+    - id: pydoclint
+```
+
+You will need to install `pre-commit` and run `pre-commit install`.
+
+### 2.5. Native vs _flake8_
 
 Should I use _pydoclint_ as a native command line tool or a _flake8_ plugin?
 Here's comparison:
@@ -70,12 +85,12 @@ Here's comparison:
 
 \*) This feature may be added in the near future
 
-### 2.4. Configuration
+### 2.5. Configuration
 
 Here is how to configure _pydoclint_. For detailed explanations of all options,
 see [Section 4](#4-configuration-options) below.
 
-#### 2.4.1. Setting options inline
+#### 2.5.1. Setting options inline
 
 - Native:
 
@@ -89,7 +104,7 @@ see [Section 4](#4-configuration-options) below.
   flake8 --check-arg-order=False <FILE_OR_FOLDER_PATH>
   ```
 
-#### 2.4.2. Setting options in a configuration file
+#### 2.5.2. Setting options in a configuration file
 
 - Native:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ set up as a hook with the following `.pre-commit-config.yaml` configuration:
 
 ```yaml
 - repo: https://github.com/jsh9/pydoclint
-  rev: 0.0.7
+  rev: <latest_tag>
   hooks:
     - id: pydoclint
       args:

--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ other built-in _flake8_ linters on your code.
 
 ### 2.3. As a pre-commit hook
 
-`pydoclint` is configured for [pre-commit](https://pre-commit.com/)
-and can be set up as a hook with the following `.pre-commit-config.yaml`
-configuration:
+`pydoclint` is configured for [pre-commit](https://pre-commit.com/) and can be
+set up as a hook with the following `.pre-commit-config.yaml` configuration:
 
 ```yaml
 - repo: https://github.com/jsh9/pydoclint


### PR DESCRIPTION
Hey thanks for the cool project ❤️ 

Since I want to replace `darglint` in my `pre-commit` configs with your project (so tired of waiting on docs to lint) it would be nice to integrate it as a stand-alone hook rather than adding it to `flake8` (my current workaround). 

Especially since I want to replace `flake8` with `ruff` anyway and `darglint` was the last big blocker.
