### PR TITLE
🩹 Fix windows encoding issues

### DIFF
--- a/.github/.pre-commit-config-self-check.yaml
+++ b/.github/.pre-commit-config-self-check.yaml
@@ -1,0 +1,12 @@
+# Used to test console encoding issues when running with pre-commit on windows
+# See: https://github.com/jsh9/pydoclint/issues/20
+
+repos:
+  - repo: local
+    hooks:
+      - id: check-self
+        name: check-self
+        entry: pydoclint --config=pyproject.toml
+        language: system
+        types: [python]
+        exclude: "^(setup\\.py$|tests?/)"

--- a/.github/.pre-commit-config-self-check.yaml
+++ b/.github/.pre-commit-config-self-check.yaml
@@ -1,4 +1,4 @@
-# Used to test console encoding issues when running with pre-commit on windows
+# Used to test console encoding issues when running with pre-commit on Windows
 # See: https://github.com/jsh9/pydoclint/issues/20
 
 repos:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,13 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        include:
-          - os: windows-latest
-            python-version: "3.8"
-          - os: macOS-latest
-            python-version: "3.8"
 
     steps:
     - uses: actions/checkout@v3
@@ -47,6 +42,8 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:
+        # This is just a sanity check, so we only run it on one Python version
+        # in order to save some time
         python-version: "3.8"
     - name: Run check-self with pre-commit
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-
+    name: Test Python ${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,11 +30,12 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: tox
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox
-        tox
+        python -m pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox
 
   test-pre-commit-console-encoding:
     # Ref.: https://github.com/jsh9/pydoclint/issues/20

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,11 +12,17 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        include:
+          - os: windows-latest
+            python-version: "3.8"
+          - os: macOS-latest
+            python-version: "3.8"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,3 +35,20 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install tox
         tox
+
+  test-pre-commit-console-encoding:
+    # Ref.: https://github.com/jsh9/pydoclint/issues/20
+    name: Test pre-commit console encoding
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+    - name: Run check-self with pre-commit
+      run: |
+        python -m pip install -e .
+        python -m pip install pre-commit
+        python -m pre_commit run check-self --all

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,4 +51,4 @@ jobs:
       run: |
         python -m pip install -e .
         python -m pip install pre-commit
-        python -m pre_commit run check-self --all
+        python -m pre_commit run -c .github/.pre-commit-config-self-check.yaml check-self --all

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,6 +50,6 @@ jobs:
         python-version: "3.8"
     - name: Run check-self with pre-commit
       run: |
-        python -m pip install -e .
-        python -m pip install pre-commit
+        python -m pip install --upgrade pip
+        python -m pip install pre-commit -e .
         python -m pre_commit run -c .github/.pre-commit-config-self-check.yaml check-self --all

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,12 +25,3 @@ repos:
     rev: v3.2.2
     hooks:
       - id: validate_manifest
-
-  - repo: local
-    hooks:
-      - id: check-self
-        name: check-self
-        entry: pydoclint --config=pyproject.toml
-        language: system
-        types: [python]
-        exclude: "^(setup\\.py$|tests?/)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,12 @@ repos:
     rev: v3.2.2
     hooks:
       - id: validate_manifest
+
+  - repo: local
+    hooks:
+      - id: check-self
+        name: check-self
+        entry: pydoclint --config=pyproject.toml
+        language: system
+        types: [python]
+        exclude: "^(setup\\.py$|tests?/)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added
   - A command line option `--version` to show the current version of pydoclint
   - Enabled pydoclint to be used as a pre-commit hook
+- Fixed
+  - Encoding issues in Windows (where non-ASCII characters cause issues with Windows + pre-commit)
 
 ## [0.0.7] - 2023-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   - A command line option `--version` to show the current version of pydoclint
   - Enabled pydoclint to be used as a pre-commit hook
 - Fixed
-  - Encoding issues in Windows (where non-ASCII characters cause issues with Windows + pre-commit)
+  - Encoding issues in Windows (where non-ASCII characters cause issues with
+    Windows + pre-commit)
 
 ## [0.0.7] - 2023-06-01
 

--- a/pydoclint/main.py
+++ b/pydoclint/main.py
@@ -166,13 +166,15 @@ def main(  # noqa: C901
     if paths and src is not None:
         click.echo(
             main.get_usage(ctx)
-            + "\n\n'paths' and 'src' cannot be passed simultaneously."
+            + "\n\n'paths' and 'src' cannot be passed simultaneously.",
+            err=True,
         )
         ctx.exit(1)
 
     if not paths and src is None:
         click.echo(
-            main.get_usage(ctx) + "\n\nOne of 'paths' or 'src' is required."
+            main.get_usage(ctx) + "\n\nOne of 'paths' or 'src' is required.",
+            err=True,
         )
         ctx.exit(1)
 
@@ -198,12 +200,14 @@ def main(  # noqa: C901
                 if counter > 1:
                     print('')
 
-                click.echo(click.style(filename, fg='yellow', bold=True))
+                click.echo(
+                    click.style(filename, fg='yellow', bold=True), err=True
+                )
                 for violation in violationsInThisFile:
                     violationCounter += 1
                     fourSpaces = '    '
-                    click.echo(fourSpaces, nl=False)
-                    click.echo(f'{violation.line}: ', nl=False)
+                    click.echo(fourSpaces, nl=False, err=True)
+                    click.echo(f'{violation.line}: ', nl=False, err=True)
                     click.echo(
                         click.style(
                             f'{violation.fullErrorCode}',
@@ -211,14 +215,18 @@ def main(  # noqa: C901
                             bold=True,
                         ),
                         nl=False,
+                        err=True,
                     )
-                    click.echo(f': {violation.msg}')
+                    click.echo(f': {violation.msg}', err=True)
 
     if violationCounter > 0:
         ctx.exit(1)
     else:
         if not quiet:
-            click.echo(click.style('🎉 No violations 🎉', fg='green', bold=True))
+            click.echo(
+                click.style('🎉 No violations 🎉', fg='green', bold=True),
+                err=True,
+            )
 
         ctx.exit(0)
 
@@ -239,7 +247,7 @@ def _checkPaths(
 
     if not quiet:
         skipMsg = f'Skipping files that match this pattern: {exclude}'
-        click.echo(click.style(skipMsg, fg='yellow', bold=True))
+        click.echo(click.style(skipMsg, fg='yellow', bold=True), err=True)
 
     excludePattern = re.compile(exclude)
 
@@ -257,7 +265,7 @@ def _checkPaths(
             continue
 
         if not quiet:
-            click.echo(click.style(filename, fg='cyan', bold=True))
+            click.echo(click.style(filename, fg='cyan', bold=True), err=True)
 
         violationsInThisFile: List[Violation] = _checkFile(
             filename,

--- a/pydoclint/main.py
+++ b/pydoclint/main.py
@@ -284,7 +284,7 @@ def _checkFile(
         allowInitDocstring: bool = False,
         requireReturnSectionWhenReturningNone: bool = False,
 ) -> List[Violation]:
-    with open(filename) as fp:
+    with open(filename, encoding='utf8') as fp:
         src: str = ''.join(fp.readlines())
 
     tree: ast.Module = ast.parse(src)

--- a/tests/data/common/non_ascii/non_ascii.py
+++ b/tests/data/common/non_ascii/non_ascii.py
@@ -1,0 +1,13 @@
+def func_non_ascii(argλ: float) -> None:
+    """Something.
+
+    Parameters
+    ----------
+    argλ : float
+        Non ASCII argument
+
+    Returns
+    -------
+    None
+    """
+    return None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -551,3 +551,14 @@ def testPlayground() -> None:
     )
     expected = []
     assert list(map(str, violations)) == expected
+
+
+def testNonAscii() -> None:
+    """Don't crash on non ASCII arguments."""
+    violations = _checkFile(
+        filename=DATA_DIR / 'common/non_ascii/non_ascii.py',
+        style='numpy',
+        skipCheckingShortDocstrings=False,
+    )
+    expected = []
+    assert list(map(str, violations)) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,12 @@ envlist =
     flake8-docstrings
     pre-commit
 
+[gh-actions]
+python =
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311, cercis, check-self, flake8-basic, flake8-misc, flake8-docstrings, pre-commit
 
 [testenv:cercis]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,9 @@ envlist =
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
-    3.10: py310
+    3.8: py38, cercis, check-self, flake8-basic, flake8-misc, flake8-docstrings, pre-commit
+    3.9: py39, cercis, check-self, flake8-basic, flake8-misc, flake8-docstrings, pre-commit
+    3.10: py310, cercis, check-self, flake8-basic, flake8-misc, flake8-docstrings, pre-commit
     3.11: py311, cercis, check-self, flake8-basic, flake8-misc, flake8-docstrings, pre-commit
 
 [testenv:cercis]


### PR DESCRIPTION
This change fixes two issues related to encoding on windows.
- A crash when using `pydoclint` as pre-commit hook due to console encoding (see #20)
- A crash when the source file contains no ASCII characters that can not be encoded using the localized system code page

In addition, I refactored the CI pipeline a bit using [`tox-gh-actions`](https://github.com/ymyzk/tox-gh-actions) to duplicate tox env execution.

Examples of the failing tests to reproduce the original issues on the CI can be found for [usage as pre-commit](https://github.com/s-weigand/pydoclint/actions/runs/5157330364/jobs/9289584540) and [file encoding](https://github.com/s-weigand/pydoclint/actions/runs/5156506653) on my fork.

closes #20 