### PR TITLE
🩹 Don't use colon after error code in message text for flake8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Fixed
   - Encoding issues in Windows (where non-ASCII characters cause issues with
     Windows + pre-commit)
+  - Stopped using colons (:) in flake8 error messages because they could cause
+    issues with tools like "yesqa"
 
 ## [0.0.7] - 2023-06-01
 

--- a/pydoclint/utils/violation.py
+++ b/pydoclint/utils/violation.py
@@ -72,4 +72,5 @@ class Violation:
     def getInfoForFlake8(self) -> Tuple[int, int, str]:
         """Get the violation info for flake8"""
         colOffset: int = 0  # we don't need column offset to locate the issue
-        return self.line, colOffset, f'{self.fullErrorCode} {self.msg}'
+        msg = f'{self.fullErrorCode} {self.msg}'  # no colon b/c that would cause 'yesqa' issues
+        return self.line, colOffset, msg

--- a/pydoclint/utils/violation.py
+++ b/pydoclint/utils/violation.py
@@ -72,4 +72,4 @@ class Violation:
     def getInfoForFlake8(self) -> Tuple[int, int, str]:
         """Get the violation info for flake8"""
         colOffset: int = 0  # we don't need column offset to locate the issue
-        return self.line, colOffset, self.__str__()
+        return self.line, colOffset, f'{self.fullErrorCode} {self.msg}'


### PR DESCRIPTION
The error code in the message passed to `flake8` should not end with `:` since this causes problems with tools like [`yesqa`](https://github.com/asottile/yesqa) that parse the `flake8` output.

E.g. this nonsense example
```py
def f(positive_nr: int):  # noqa: DOC502
    """Does something.

    Parameters
    ----------
    positive_nr : int
        Used to do something

    Raises
    ------
    ValueError
        If ``positive_nr`` is not a positive number.
    """
    ensure_positive(positive_nr) # raise value error if positive_nr is not positive
    result = ...
    return result
```
In this case `yesqa` would remove the `noqa` since it sees the error code reported as `DOC502:` instead of `DOC502` (It uses flake8 formatting string `--format=%(row)d\t%(code)s`) which then does not match and the noqa gets removed.
