### PR TITLE
Editorconfig and enable prettier for yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
@@ -20,17 +20,17 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox tox-gh-actions
-    - name: Test with tox
-      run: tox
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox tox-gh-actions
+      - name: Test with tox
+        run: tox
 
   test-pre-commit-console-encoding:
     # Ref.: https://github.com/jsh9/pydoclint/issues/20
@@ -38,15 +38,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v3
-      with:
-        # This is just a sanity check, so we only run it on one Python version
-        # in order to save some time
-        python-version: "3.8"
-    - name: Run check-self with pre-commit
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pre-commit -e .
-        python -m pre_commit run -c .github/.pre-commit-config-self-check.yaml check-self --all
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          # This is just a sanity check, so we only run it on one Python version
+          # in order to save some time
+          python-version: "3.8"
+      - name: Run check-self with pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pre-commit -e .
+          python -m pre_commit run -c .github/.pre-commit-config-self-check.yaml check-self --all

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,23 +17,22 @@ permissions:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,6 @@ repos:
     rev: v2.7.1
     hooks:
       - id: prettier
-        exclude: .*\.ya?ml
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
--   id: pydoclint
-    name: pydoclint
-    description: 'A Python docstring linter that checks arguments, returns, yields, and raises sections'
-    entry: pydoclint
-    language: python
-    types: [python]
+- id: pydoclint
+  name: pydoclint
+  description: "A Python docstring linter that checks arguments, returns, yields, and raises sections"
+  entry: pydoclint
+  language: python
+  types: [python]

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,3 +1,6 @@
-proseWrap: always
 printWidth: 79
 endOfLine: auto
+overrides:
+  - files: "*.md"
+    options:
+      proseWrap: always


### PR DESCRIPTION
Since the exclude is only configured in pre-commit. Editors and prettier itself will format yaml files with proseWrap=always. This is a problem for YAML. So why not configure prettier and editors through .editorconfig correctly so that it can be used to enforce proper formatting of YAML files.