### PR TITLE
Silence config messages and quiet pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
   entry: pydoclint
   language: python
   types: [python]
+  args: ["--quiet"]

--- a/pydoclint/main.py
+++ b/pydoclint/main.py
@@ -6,9 +6,7 @@ from typing import Dict, List, Optional, Tuple
 import click
 
 from pydoclint import __version__
-from pydoclint.parse_config import (
-    injectDefaultOptionsFromUserSpecifiedTomlFilePath,
-)
+from pydoclint.parse_config import parseConfig
 from pydoclint.utils.violation import Violation
 from pydoclint.visitor import Visitor
 
@@ -150,7 +148,6 @@ def validateStyleValue(
         path_type=str,
     ),
     is_eager=True,
-    callback=injectDefaultOptionsFromUserSpecifiedTomlFilePath,
     help=(
         'The full path of the .toml config file that contains the config'
         ' options; note that the command line options take precedence'
@@ -177,6 +174,13 @@ def main(  # noqa: C901
 ) -> None:
     """Command-line entry point of pydoclint"""
     ctx.ensure_object(dict)
+
+    if config:
+        parseConfig(
+            ctx=ctx,
+            file=config,
+            quiet=quiet,
+        )
 
     if paths and src is not None:
         click.echo(


### PR DESCRIPTION
pydoclint would display such a message even if the quiet flag is enabled:
```
Loading config from user-specified .toml file: ../pyproject.toml
Found options defined in ..\pyproject.toml:
{'style': 'numpy', 'exclude': '\\.git|\\.tox|tests/data|unparser\\.py', 'require_return_section_when_returning_none': True}
```

This pull request disables this message if the flag is enabled. It also enables the flag by default for the pre-commit hook as you want the pre-commit hook to be as silent as possible unless there's an issue.

PS: I feel like these messages (in particular the one displaying the config content) would be good candidates for the use of the logging module. For example:
* `Loading config from user-specified .toml file` --> logging.info
* `Found options defined in pyproject.toml` --> logging.debug
* `{'style': 'numpy', 'exclude': '\\.git|\\.tox|tests/data|unparser\\.py', 'require_return_section_when_returning_none': True}` --> logging.debug

This way it would be much easier to control the verbosity of the logging