### PR TITLE
Parse '--check-return-types' in flake8 plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.1.3] - 2023-07-21
+
+- Fixed
+  - Pass `--check-return-types` option to flake8 plugin
+- Full diff
+  - https://github.com/jsh9/pydoclint/compare/0.1.2...0.1.3
+
 ## [0.1.2] - 2023-07-20
 
 - Fixed

--- a/pydoclint/flake8_entry.py
+++ b/pydoclint/flake8_entry.py
@@ -129,6 +129,7 @@ class Plugin:
         cls.require_return_section_when_returning_none = (
             options.require_return_section_when_returning_none
         )
+        cls.check_return_types = options.check_return_types
         cls.style = options.style
 
     def run(self) -> Generator[Tuple[int, int, str, Any], None, None]:
@@ -170,6 +171,10 @@ class Plugin:
             '--require-return-section-when-returning-none',
             self.require_return_section_when_returning_none,
         )
+        checkReturnTypes = self._bool(
+            '--check-return-types',
+            self.check_return_types,
+        )
 
         if self.style not in {'numpy', 'google', 'sphinx'}:
             raise ValueError(
@@ -184,6 +189,7 @@ class Plugin:
             skipCheckingRaises=skipCheckingRaises,
             allowInitDocstring=allowInitDocstring,
             requireReturnSectionWhenReturningNone=requireReturnSectionWhenReturningNone,
+            checkReturnTypes=checkReturnTypes,
             style=self.style,
         )
         v.visit(self._tree)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoclint
-version = 0.1.2
+version = 0.1.3
 description = A Python docstring linter that checks arguments, returns, yields, and raises sections
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
The argument was already defined, but never passed on to the AST visitor.