### PR TITLE
Handle syntax errors in type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.1.7] - 2023-08-15
+
+- Fixed
+  - Correctly handle potentially unacceptable type hint formats
+- Full diff
+  - https://github.com/jsh9/pydoclint/compare/0.1.6...0.1.7
+
 ## [0.1.6] - 2023-08-13
 
 - Added

--- a/docs/how_to_ignore.md
+++ b/docs/how_to_ignore.md
@@ -1,6 +1,8 @@
-# How to ignore certain violations in *flake8* mode
+# How to ignore certain violations in _flake8_ mode
 
-In *flake8* mode (meaning that you use *pydoclint* as a flake8 plugin), if you'd like to ignore a specific violation code (such as `DOC201` and `DOC301`) in-line, you can add this comment to the function of your choice:
+In _flake8_ mode (meaning that you use _pydoclint_ as a flake8 plugin), if
+you'd like to ignore a specific violation code (such as `DOC201` and `DOC301`)
+in-line, you can add this comment to the function of your choice:
 
 ```python
 def my_function(  # noqa: DOC201, DOC301
@@ -10,7 +12,8 @@ def my_function(  # noqa: DOC201, DOC301
     ...
 ```
 
-If you would like to ignore certain categories of violations (such as `DOC2xx`) in-line, you can do this:
+If you would like to ignore certain categories of violations (such as `DOC2xx`)
+in-line, you can do this:
 
 ```python
 def my_function(  # noqa: DOC2
@@ -20,4 +23,6 @@ def my_function(  # noqa: DOC2
     ...
 ```
 
-All the usage is consistent with how you would use *flake8*.  Please read the official *flake8* documentation for full details: https://flake8.pycqa.org/en/latest/user/violations.html.
+All the usage is consistent with how you would use _flake8_. Please read the
+official _flake8_ documentation for full details:
+https://flake8.pycqa.org/en/latest/user/violations.html.

--- a/pydoclint/utils/arg.py
+++ b/pydoclint/utils/arg.py
@@ -102,8 +102,16 @@ class Arg:
         # >>>     "def",
         # >>>     "ghi",
         # >>> ]
-        str1_: str = unparseAnnotation(ast.parse(stripQuotes(str1)))
-        str2_: str = unparseAnnotation(ast.parse(stripQuotes(str2)))
+        try:
+            str1_: str = unparseAnnotation(ast.parse(stripQuotes(str1)))
+        except SyntaxError:
+            str1_ = str1
+
+        try:
+            str2_: str = unparseAnnotation(ast.parse(stripQuotes(str2)))
+        except SyntaxError:
+            str2_ = str2
+
         return str1_ == str2_
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoclint
-version = 0.1.6
+version = 0.1.7
 description = A Python docstring linter that checks arguments, returns, yields, and raises sections
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/data/edge_cases/edge_case_02_syntax_error_in_type_hints.py
+++ b/tests/data/edge_cases/edge_case_02_syntax_error_in_type_hints.py
@@ -1,0 +1,31 @@
+def func1(a='a'):
+    """
+    Title
+
+    Parameters
+    ----------
+    a : str, default a
+    """
+    pass
+
+
+def func2(a='a'):
+    """
+    Title
+
+    Parameters
+    ----------
+    a : str, default=a
+    """
+    pass
+
+
+def func3(a='a'):
+    """
+    Title
+
+    Parameters
+    ----------
+    a : str, default: a
+    """
+    pass

--- a/tests/data/edge_cases/edge_case_02_syntax_error_in_type_hints.py
+++ b/tests/data/edge_cases/edge_case_02_syntax_error_in_type_hints.py
@@ -1,3 +1,6 @@
+# Related issue: https://github.com/jsh9/pydoclint/issues/59
+
+
 def func1(a='a'):
     """
     Title

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -833,6 +833,27 @@ def testNonAscii() -> None:
     'filename, options, expectedViolations',
     [
         ('edge_case_01.py', {'style': 'sphinx'}, []),
+        (
+            'edge_case_02_syntax_error_in_type_hints.py',
+            {'style': 'numpy'},
+            [
+                'DOC106: Function `func1`: The option `--arg-type-hints-in-signature` is '
+                '`True` but there are no argument type hints in the signature ',
+                'DOC107: Function `func1`: The option `--arg-type-hints-in-signature` is '
+                '`True` but not all args in the signature have type hints ',
+                'DOC105: Function `func1`: Argument names match, but type hints do not match ',
+                'DOC106: Function `func2`: The option `--arg-type-hints-in-signature` is '
+                '`True` but there are no argument type hints in the signature ',
+                'DOC107: Function `func2`: The option `--arg-type-hints-in-signature` is '
+                '`True` but not all args in the signature have type hints ',
+                'DOC105: Function `func2`: Argument names match, but type hints do not match ',
+                'DOC106: Function `func3`: The option `--arg-type-hints-in-signature` is '
+                '`True` but there are no argument type hints in the signature ',
+                'DOC107: Function `func3`: The option `--arg-type-hints-in-signature` is '
+                '`True` but not all args in the signature have type hints ',
+                'DOC105: Function `func3`: Argument names match, but type hints do not match ',
+            ],
+        ),
     ],
 )
 def testEdgeCases(


### PR DESCRIPTION
Fixes https://github.com/jsh9/pydoclint/issues/59