### PR TITLE
Exclude venv folders in flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,5 @@ wrap-line-with-long-string = true
 
 [tool.pydoclint]
 style = 'numpy'
-exclude = '\.git|\.tox|tests/data|unparser\.py'
+exclude = '\.git|.?venv|\.tox|tests/data|unparser\.py'
 require-return-section-when-returning-nothing = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,9 @@ flake8.extension =
 
 [bdist_wheel]
 universal = True
+
+[flake8]
+exclude =
+    .tox,
+    .venv,
+    venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,9 +37,3 @@ flake8.extension =
 
 [bdist_wheel]
 universal = True
-
-[flake8]
-exclude =
-    .tox,
-    .venv,
-    venv

--- a/tox.ini
+++ b/tox.ini
@@ -101,5 +101,6 @@ statistics = true
 max-complexity = 10
 exclude =
     .*,
+    venv/*,
     tests/data/*,
     unparser.py


### PR DESCRIPTION
In CI, dependencies are installed to system Python. For developers, it's common to use a virtual environment named `venv` or `.venv`.  This PR adds ignores for those to `flake8` and `pydoclint`