### PR TITLE
tox: use `deps = .` instead of `pip install`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,8 +72,8 @@ commands =
 
 
 [testenv:check-self]
+deps = .
 commands =
-    pip install -e .
     pydoclint --config=pyproject.toml .
 
 


### PR DESCRIPTION
If a user is using `tox-uv` (a plugin for tox that supports running the various `pip` commands vi `uv`), then `pip install .` is seen as an external command, which would require `allowlist_externals`. Instead, install the local project by specifying it as a dep. Then, regular tox and tox-uv both will install it as `pip install .` or `uv pip install .`, respectively.

----

tested with `tox 4.16.0`, with and without `tox-uv-1.9.0` installed.
- https://github.com/tox-dev/tox-uv