### PR TITLE
feat: introduce DOC503 for checking specific raised exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
-## [unpublished] - 2024-08-05
+## [0.5.7] - 2024-09-02
+
+- Added
+
+  - A new violation code, `DOC503`, which checks that exceptions in the
+    function body match those in the "Raises" section of the docstring
 
 - Changed
   - Switched from tab to 4 spaces in baseline

--- a/docs/violation_codes.md
+++ b/docs/violation_codes.md
@@ -87,6 +87,7 @@ have a return section.
 | -------- | --------------------------------------------------------------------------------------------------------- |
 | `DOC501` | Function/method has "raise" statements, but the docstring does not have a "Raises" section                |
 | `DOC502` | Function/method has a "Raises" section in the docstring, but there are not "raise" statements in the body |
+| `DOC503` | Exceptions in the "Raises" section in the docstring do not match those in the function body               |
 
 ## 6. `DOC6xx`: Violations about class attributes
 

--- a/pydoclint/utils/return_yield_raise.py
+++ b/pydoclint/utils/return_yield_raise.py
@@ -109,7 +109,8 @@ def _getRaisedExceptions(
 
     currentParentExceptHandler: Optional[ast.ExceptHandler] = None
 
-    # depth-first guarantees the last-seen exception handler is a parent of child.
+    # Depth-first guarantees the last-seen exception handler
+    # is a parent of child.
     for child, parent in walk.walk_dfs(node):
         childLineNum = _updateFamilyTree(child, parent, familyTree)
 

--- a/pydoclint/utils/return_yield_raise.py
+++ b/pydoclint/utils/return_yield_raise.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Callable, Dict, Generator, List, Tuple, Type
+from typing import Callable, Dict, Generator, List, Optional, Tuple, Type
 
 from pydoclint.utils import walk
 from pydoclint.utils.annotation import unparseAnnotation
@@ -107,8 +107,14 @@ def _getRaisedExceptions(
     # key: child lineno, value: (parent lineno, is parent a function?)
     familyTree: Dict[int, Tuple[int, bool]] = {}
 
-    for child, parent in walk.walk(node):
+    currentParentExceptHandler: Optional[ast.ExceptHandler] = None
+
+    # depth-first guarantees the last-seen exception handler is a parent of child.
+    for child, parent in walk.walk_dfs(node):
         childLineNum = _updateFamilyTree(child, parent, familyTree)
+
+        if isinstance(parent, ast.ExceptHandler):
+            currentParentExceptHandler = parent
 
         if (
             isinstance(child, ast.Raise)
@@ -123,15 +129,28 @@ def _getRaisedExceptions(
                 lineNumOfThisNode=node.lineno,
             )
         ):
-            for subnode, _ in walk.walk(child):
+            for subnode, _ in walk.walk_dfs(child):
                 if isinstance(subnode, ast.Name):
                     yield subnode.id
                     break
             else:
-                # if "raise" statement was alone, generally parent is ast.ExceptHandler.
-                for subnode, _ in walk.walk(parent):
-                    if isinstance(subnode, ast.Name):
-                        yield subnode.id
+                # if "raise" statement was alone, it must be inside an "except"
+                if currentParentExceptHandler:
+                    yield from _extractExceptionsFromExcept(
+                        currentParentExceptHandler,
+                    )
+
+
+def _extractExceptionsFromExcept(
+        node: ast.ExceptHandler,
+) -> Generator[str, None, None]:
+    if isinstance(node.type, ast.Name):
+        yield node.type.id
+
+    if isinstance(node.type, ast.Tuple):
+        for child, _ in walk.walk(node.type):
+            if isinstance(child, ast.Name):
+                yield child.id
 
 
 def _hasExpectedStatements(

--- a/pydoclint/utils/violation.py
+++ b/pydoclint/utils/violation.py
@@ -52,6 +52,7 @@ VIOLATION_CODES = types.MappingProxyType({
 
     501: 'has "raise" statements, but the docstring does not have a "Raises" section',
     502: 'has a "Raises" section in the docstring, but there are not "raise" statements in the body',
+    503: 'exceptions in "raises" section do not match those in body.',
 
     601: 'Class docstring contains fewer class attributes than actual class attributes.',
     602: 'Class docstring contains more class attributes than in actual class attributes.',

--- a/pydoclint/utils/violation.py
+++ b/pydoclint/utils/violation.py
@@ -52,7 +52,7 @@ VIOLATION_CODES = types.MappingProxyType({
 
     501: 'has "raise" statements, but the docstring does not have a "Raises" section',
     502: 'has a "Raises" section in the docstring, but there are not "raise" statements in the body',
-    503: 'exceptions in "raises" section do not match those in body.',
+    503: 'exceptions in the "Raises" section in the docstring do not match those in the function body',
 
     601: 'Class docstring contains fewer class attributes than actual class attributes.',
     602: 'Class docstring contains more class attributes than in actual class attributes.',

--- a/pydoclint/utils/visitor_helper.py
+++ b/pydoclint/utils/visitor_helper.py
@@ -523,7 +523,7 @@ def extractReturnTypeFromGenerator(returnAnnoText: str) -> str:
     return stripQuotes(returnType)
 
 
-def messageForMismatchedRaisedExceptions(
+def addMismatchedRaisesExceptionViolation(
         *,
         docRaises: List[str],
         actualRaises: List[str],
@@ -532,17 +532,19 @@ def messageForMismatchedRaisedExceptions(
         lineNum: int,
         msgPrefix: str,
 ) -> None:
-    """Format a violation message for mismatched raised exceptions between body and docstring"""
-    msgPostfixTemp: str = ' '.join([
-        f'Raises values in the docstring: {docRaises}.',
-        f'Raised exceptions in the body: {actualRaises}.',
-    ])
-
+    """
+    Add a violation for mismatched exception type between function
+    body and docstring
+    """
+    msgPostfix: str = (
+        f'Raises values in the docstring: {docRaises}.'
+        f' Raised exceptions in the body: {actualRaises}.'
+    )
     violations.append(
         Violation(
-            code=503,
+            code=violationForRaisesMismatch.code,
             line=lineNum,
             msgPrefix=msgPrefix,
-            msgPostfix=msgPostfixTemp,
+            msgPostfix=msgPostfix,
         )
     )

--- a/pydoclint/utils/visitor_helper.py
+++ b/pydoclint/utils/visitor_helper.py
@@ -521,3 +521,28 @@ def extractReturnTypeFromGenerator(returnAnnoText: str) -> str:
         returnType = returnAnnoText
 
     return stripQuotes(returnType)
+
+
+def messageForMismatchedRaisedExceptions(
+        *,
+        docRaises: List[str],
+        actualRaises: List[str],
+        violations: List[Violation],
+        violationForRaisesMismatch: Violation,  # such as V503
+        lineNum: int,
+        msgPrefix: str,
+) -> None:
+    """Format a violation message for mismatched raised exceptions between body and docstring"""
+    msgPostfixTemp: str = ' '.join([
+        f'Raises values in the docstring: {docRaises}.',
+        f'Raised exceptions in the body: {actualRaises}.',
+    ])
+
+    violations.append(
+        Violation(
+            code=503,
+            line=lineNum,
+            msgPrefix=msgPrefix,
+            msgPostfix=msgPostfixTemp,
+        )
+    )

--- a/pydoclint/utils/walk.py
+++ b/pydoclint/utils/walk.py
@@ -33,9 +33,9 @@ def walk(node):
 
 
 def walk_dfs(node):
-    """Depth-first traversal of AST. Modified from walk.walk, above."""
+    """Depth-first traversal of AST. Modified from `walk()` in this file"""
     for child, parent in iter_child_nodes(node):
-        yield (child, parent)
+        yield child, parent
         yield from walk_dfs(child)
 
 

--- a/pydoclint/utils/walk.py
+++ b/pydoclint/utils/walk.py
@@ -32,6 +32,13 @@ def walk(node):
         yield node, parent
 
 
+def walk_dfs(node):
+    """Depth-first traversal of AST. Modified from walk.walk, above."""
+    for child, parent in iter_child_nodes(node):
+        yield (child, parent)
+        yield from walk_dfs(child)
+
+
 def iter_child_nodes(node):
     """
     Yield all direct child nodes of *node*, that is, all fields that are nodes

--- a/pydoclint/visitor.py
+++ b/pydoclint/visitor.py
@@ -33,6 +33,7 @@ from pydoclint.utils.special_methods import (
 )
 from pydoclint.utils.violation import Violation
 from pydoclint.utils.visitor_helper import (
+    addMismatchedRaisesExceptionViolation,
     checkClassAttributesAgainstClassDocstring,
     checkDocArgsLengthAgainstActualArgs,
     checkNameOrderAndTypeHintsOfDocArgsAgainstActualArgs,
@@ -40,7 +41,6 @@ from pydoclint.utils.visitor_helper import (
     checkYieldTypesForViolations,
     extractReturnTypeFromGenerator,
     extractYieldTypeFromGeneratorOrIteratorAnnotation,
-    messageForMismatchedRaisedExceptions,
 )
 from pydoclint.utils.yield_arg import YieldArg
 
@@ -813,7 +813,7 @@ class Visitor(ast.NodeVisitor):
 
         v501 = Violation(code=501, line=lineNum, msgPrefix=msgPrefix)
         v502 = Violation(code=502, line=lineNum, msgPrefix=msgPrefix)
-        v503 = Violation(code=502, line=lineNum, msgPrefix=msgPrefix)
+        v503 = Violation(code=503, line=lineNum, msgPrefix=msgPrefix)
 
         docstringHasRaisesSection: bool = doc.hasRaisesSection
         hasRaiseStmt: bool = hasRaiseStatements(node)
@@ -832,7 +832,6 @@ class Visitor(ast.NodeVisitor):
             for raises in doc.parsed.raises:
                 if raises.type_name:
                     docRaises.append(raises.type_name)
-
                 elif doc.style == 'sphinx' and raises.description:
                     # :raises: Exception: -> 'Exception'
                     splitDesc = raises.description.split(':')
@@ -844,7 +843,7 @@ class Visitor(ast.NodeVisitor):
             actualRaises = getRaisedExceptions(node)
 
             if docRaises != actualRaises:
-                messageForMismatchedRaisedExceptions(
+                addMismatchedRaisesExceptionViolation(
                     docRaises=docRaises,
                     actualRaises=actualRaises,
                     violations=violations,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoclint
-version = 0.5.6
+version = 0.5.7
 description = A Python docstring linter that checks arguments, returns, yields, and raises sections
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/data/google/raises/cases.py
+++ b/tests/data/google/raises/cases.py
@@ -143,3 +143,42 @@ class B:
                 raise
 
         print(arg0)
+
+    def func11(self, arg0) -> None:
+        """
+        This docstring doesn't specify all the raised exceptions.
+
+        Args:
+            arg0: Arg 0
+
+        Raises:
+            TypeError: if arg0 is 0.
+        """
+        if arg0 == 0:
+            raise TypeError
+        raise ValueError
+
+    def func12(self, arg0) -> None:
+        """
+        There should not be any violations in this method.
+
+        Args:
+            arg0: Arg 0
+
+        Raises:
+            TypeError: if arg0 is 0.
+            ValueError: otherwise.
+        """
+        if arg0 == 0:
+            raise TypeError
+        raise ValueError
+
+    def func13(self) -> None:
+        """
+        Should raise an error due to duplicated raises.
+
+        Raises:
+            ValueError: all the time.
+            ValueError: typo!
+        """
+        raise ValueError

--- a/tests/data/numpy/raises/cases.py
+++ b/tests/data/numpy/raises/cases.py
@@ -178,3 +178,54 @@ class B:
                 raise
 
         print(arg0)
+
+    def func11(self, arg0) -> None:
+        """
+        This docstring doesn't specify all the raised exceptions.
+
+        Parameters
+        ----------
+        arg0
+            Arg 0
+
+        Raises
+        ------
+        TypeError
+            if arg0 is 0.
+        """
+        if arg0 == 0:
+            raise TypeError
+        raise ValueError
+
+    def func12(self, arg0) -> None:
+        """
+        There should not be any violations in this method.
+
+        Parameters
+        ----------
+        arg0
+            Arg 0
+
+        Raises
+        ------
+        TypeError
+            if arg0 is 0.
+        ValueError
+            otherwise.
+        """
+        if arg0 == 0:
+            raise TypeError
+        raise ValueError
+
+    def func13(self) -> None:
+        """
+        Should raise an error due to duplicated raises.
+
+        Raises
+        ------
+        ValueError
+            all the time.
+        ValueError
+            typo!
+        """
+        raise ValueError

--- a/tests/data/sphinx/raises/cases.py
+++ b/tests/data/sphinx/raises/cases.py
@@ -121,3 +121,35 @@ class B:
                 raise
 
         print(arg0)
+
+    def func11(self, arg0) -> None:
+        """
+        This docstring doesn't specify all the raised exceptions.
+
+        :param arg0: Arg 0
+        :raises TypeError: if arg0 is zero.
+        """
+        if arg0 == 0:
+            raise TypeError
+        raise ValueError
+
+    def func12(self, arg0) -> None:
+        """
+        There should not be any violations in this method.
+
+        :param arg0: Arg 0
+        :raises TypeError: if arg0 is zero.
+        :raises ValueError: otherwise.
+        """
+        if arg0 == 0:
+            raise TypeError
+        raise ValueError
+
+    def func13(self) -> None:
+        """
+        Should raise an error due to duplicated raises.
+
+        :raises ValueError: all the time.
+        :raises ValueError: typo!
+        """
+        raise ValueError

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -609,9 +609,9 @@ def testAllowInitDocstring(style: str) -> None:
         'because __init__() cannot return anything',
         'DOC305: Class `C`: Class docstring has a "Raises" section; please put it in '
         'the __init__() docstring',
-        'DOC503: Method `C.__init__` exceptions in "raises" section do not match '
-        "those in body. Raises values in the docstring: ['TypeError']. Raised "
-        "exceptions in the body: ['ValueError'].",
+        'DOC503: Method `C.__init__` exceptions in the "Raises" section in the '
+        'docstring do not match those in the function body Raises values in the '
+        "docstring: ['TypeError']. Raised exceptions in the body: ['ValueError'].",
         'DOC306: Class `D`: The class docstring does not need a "Yields" section, '
         'because __init__() cannot yield anything',
         'DOC307: Class `D`: The __init__() docstring does not need a "Yields" '
@@ -807,12 +807,12 @@ def testRaises(style: str, skipRaisesCheck: bool) -> None:
     expected0 = [
         'DOC501: Method `B.func1` has "raise" statements, but the docstring does not '
         'have a "Raises" section',
-        'DOC503: Method `B.func1` exceptions in "raises" section do not match those '
-        'in body. Raises values in the docstring: []. Raised exceptions in '
-        "the body: ['ValueError'].",
-        'DOC503: Method `B.func4` exceptions in "raises" section do not match those '
-        "in body. Raises values in the docstring: ['CurtomError']. Raised exceptions in "
-        "the body: ['CustomError'].",
+        'DOC503: Method `B.func1` exceptions in the "Raises" section in the docstring '
+        'do not match those in the function body Raises values in the docstring: []. '
+        "Raised exceptions in the body: ['ValueError'].",
+        'DOC503: Method `B.func4` exceptions in the "Raises" section in the docstring '
+        'do not match those in the function body Raises values in the docstring: '
+        "['CurtomError']. Raised exceptions in the body: ['CustomError'].",
         'DOC502: Method `B.func5` has a "Raises" section in the docstring, but there '
         'are not "raise" statements in the body',
         'DOC502: Method `B.func7` has a "Raises" section in the docstring, but there '
@@ -821,15 +821,17 @@ def testRaises(style: str, skipRaisesCheck: bool) -> None:
         'are not "raise" statements in the body',
         'DOC501: Function `inner9a` has "raise" statements, but the docstring does '
         'not have a "Raises" section',
-        'DOC503: Function `inner9a` exceptions in "raises" section do not match those '
-        'in body. Raises values in the docstring: []. Raised exceptions in '
-        "the body: ['FileNotFoundError'].",
-        'DOC503: Method `B.func11` exceptions in "raises" section do not match those '
-        "in body. Raises values in the docstring: ['TypeError']. Raised exceptions in "
-        "the body: ['TypeError', 'ValueError'].",
-        'DOC503: Method `B.func13` exceptions in "raises" section do not match those '
-        "in body. Raises values in the docstring: ['ValueError', 'ValueError']. "
-        "Raised exceptions in the body: ['ValueError'].",
+        'DOC503: Function `inner9a` exceptions in the "Raises" section in the '
+        'docstring do not match those in the function body Raises values in the '
+        "docstring: []. Raised exceptions in the body: ['FileNotFoundError'].",
+        'DOC503: Method `B.func11` exceptions in the "Raises" section in the '
+        'docstring do not match those in the function body Raises values in the '
+        "docstring: ['TypeError']. Raised exceptions in the body: ['TypeError', "
+        "'ValueError'].",
+        'DOC503: Method `B.func13` exceptions in the "Raises" section in the '
+        'docstring do not match those in the function body Raises values in the '
+        "docstring: ['ValueError', 'ValueError']. Raised exceptions in the body: "
+        "['ValueError'].",
     ]
     expected1 = []
     expected = expected1 if skipRaisesCheck else expected0
@@ -859,9 +861,9 @@ def testRaisesPy310plus(style: str, skipRaisesCheck: bool) -> None:
     expected0 = [
         'DOC501: Method `B.func10` has "raise" statements, but the docstring does not '
         'have a "Raises" section',
-        'DOC503: Method `B.func10` exceptions in "raises" section do not match those '
-        'in body. Raises values in the docstring: []. Raised exceptions in '
-        "the body: ['ValueError'].",
+        'DOC503: Method `B.func10` exceptions in the "Raises" section in the '
+        'docstring do not match those in the function body Raises values in the '
+        "docstring: []. Raised exceptions in the body: ['ValueError'].",
     ]
     expected1 = []
     expected = expected1 if skipRaisesCheck else expected0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -609,6 +609,9 @@ def testAllowInitDocstring(style: str) -> None:
         'because __init__() cannot return anything',
         'DOC305: Class `C`: Class docstring has a "Raises" section; please put it in '
         'the __init__() docstring',
+        'DOC503: Method `C.__init__` exceptions in "raises" section do not match '
+        "those in body. Raises values in the docstring: ['TypeError']. Raised "
+        "exceptions in the body: ['ValueError'].",
         'DOC306: Class `D`: The class docstring does not need a "Yields" section, '
         'because __init__() cannot yield anything',
         'DOC307: Class `D`: The __init__() docstring does not need a "Yields" '
@@ -804,6 +807,12 @@ def testRaises(style: str, skipRaisesCheck: bool) -> None:
     expected0 = [
         'DOC501: Method `B.func1` has "raise" statements, but the docstring does not '
         'have a "Raises" section',
+        'DOC503: Method `B.func1` exceptions in "raises" section do not match those '
+        'in body. Raises values in the docstring: []. Raised exceptions in '
+        "the body: ['ValueError'].",
+        'DOC503: Method `B.func4` exceptions in "raises" section do not match those '
+        "in body. Raises values in the docstring: ['CurtomError']. Raised exceptions in "
+        "the body: ['CustomError'].",
         'DOC502: Method `B.func5` has a "Raises" section in the docstring, but there '
         'are not "raise" statements in the body',
         'DOC502: Method `B.func7` has a "Raises" section in the docstring, but there '
@@ -812,6 +821,15 @@ def testRaises(style: str, skipRaisesCheck: bool) -> None:
         'are not "raise" statements in the body',
         'DOC501: Function `inner9a` has "raise" statements, but the docstring does '
         'not have a "Raises" section',
+        'DOC503: Function `inner9a` exceptions in "raises" section do not match those '
+        'in body. Raises values in the docstring: []. Raised exceptions in '
+        "the body: ['FileNotFoundError'].",
+        'DOC503: Method `B.func11` exceptions in "raises" section do not match those '
+        "in body. Raises values in the docstring: ['TypeError']. Raised exceptions in "
+        "the body: ['TypeError', 'ValueError'].",
+        'DOC503: Method `B.func13` exceptions in "raises" section do not match those '
+        "in body. Raises values in the docstring: ['ValueError', 'ValueError']. "
+        "Raised exceptions in the body: ['ValueError'].",
     ]
     expected1 = []
     expected = expected1 if skipRaisesCheck else expected0
@@ -841,6 +859,9 @@ def testRaisesPy310plus(style: str, skipRaisesCheck: bool) -> None:
     expected0 = [
         'DOC501: Method `B.func10` has "raise" statements, but the docstring does not '
         'have a "Raises" section',
+        'DOC503: Method `B.func10` exceptions in "raises" section do not match those '
+        'in body. Raises values in the docstring: []. Raised exceptions in '
+        "the body: ['ValueError'].",
     ]
     expected1 = []
     expected = expected1 if skipRaisesCheck else expected0

--- a/tests/utils/test_returns_yields_raise.py
+++ b/tests/utils/test_returns_yields_raise.py
@@ -382,6 +382,40 @@ def func10():
         1 / 0
     except GError:
         raise
+
+def func11(a):
+    # Duplicated exceptions will only be reported once
+    if a < 1:
+        raise ValueError
+
+    if a < 2:
+        raise ValueError
+
+    if a < 3:
+        raise ValueError
+
+    if a < 4:
+        raise ValueError
+
+    if a < 5:
+        raise ValueError
+
+def func12(a):
+    # Exceptions will be reported in alphabetical order, regardless of
+    # the order they are raised within the function body
+
+    Error1 = RuntimeError
+    Error2 = ValueError
+    Error3 = TypeError
+
+    if a < 1:
+        raise Error2
+
+    if a < 2:
+        raise Error1
+
+    if a < 3:
+        raise Error3
 """
 
 
@@ -403,6 +437,8 @@ def testHasRaiseStatements() -> None:
         (54, 0, 'func8'): True,
         (62, 0, 'func9'): True,
         (75, 0, 'func10'): True,
+        (83, 0, 'func11'): True,
+        (100, 0, 'func12'): True,
     }
 
     assert result == expected
@@ -431,6 +467,8 @@ def testWhichRaiseStatements() -> None:
         (54, 0, 'func8'): ['KeyError', 'TypeError'],
         (62, 0, 'func9'): ['AssertionError', 'IndexError'],
         (75, 0, 'func10'): ['GError'],
+        (83, 0, 'func11'): ['ValueError'],
+        (100, 0, 'func12'): ['Error1', 'Error2', 'Error3'],
     }
 
     assert result == expected

--- a/tests/utils/test_returns_yields_raise.py
+++ b/tests/utils/test_returns_yields_raise.py
@@ -345,6 +345,43 @@ def func7(arg0):
         1 / 0
     except ZeroDivisionError:
         raise RuntimeError("a different error")
+
+    try:
+        pass
+    except OSError as e:
+        if e.args[0] == 2 and e.filename:
+            fp = None
+        else:
+            raise
+
+def func8(d):
+    try:
+        d[0][0]
+    except (KeyError, TypeError):
+        raise
+    finally:
+        pass
+
+def func9(d):
+    try:
+        d[0]
+    except IndexError:
+        try:
+            d[0][0]
+        except KeyError:
+            raise AssertionError() from e
+        except Exception:
+            pass
+        if True:
+            raise
+
+def func10():
+    # no variable resolution is done. this function looks like it throws "GError".
+    GError = ZeroDivisionError
+    try:
+        1 / 0
+    except GError:
+        raise
 """
 
 
@@ -363,6 +400,9 @@ def testHasRaiseStatements() -> None:
         (26, 0, 'func6'): True,
         (21, 4, 'func5_child1'): True,
         (32, 0, 'func7'): True,
+        (54, 0, 'func8'): True,
+        (62, 0, 'func9'): True,
+        (75, 0, 'func10'): True,
     }
 
     assert result == expected
@@ -382,7 +422,15 @@ def testWhichRaiseStatements() -> None:
         (20, 0, 'func5'): [],
         (26, 0, 'func6'): ['TypeError'],
         (21, 4, 'func5_child1'): ['ValueError'],
-        (32, 0, 'func7'): ['IndexError', 'RuntimeError', 'TypeError'],
+        (32, 0, 'func7'): [
+            'IndexError',
+            'OSError',
+            'RuntimeError',
+            'TypeError',
+        ],
+        (54, 0, 'func8'): ['KeyError', 'TypeError'],
+        (62, 0, 'func9'): ['AssertionError', 'IndexError'],
+        (75, 0, 'func10'): ['GError'],
     }
 
     assert result == expected

--- a/tests/utils/test_returns_yields_raise.py
+++ b/tests/utils/test_returns_yields_raise.py
@@ -376,7 +376,7 @@ def func9(d):
             raise
 
 def func10():
-    # no variable resolution is done. this function looks like it throws "GError".
+    # no variable resolution is done. this function looks like it throws GError.
     GError = ZeroDivisionError
     try:
         1 / 0

--- a/tests/utils/test_walk.py
+++ b/tests/utils/test_walk.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 
 import pytest
 
-from pydoclint.utils.walk import walk
+from pydoclint.utils.walk import walk, walk_dfs
 
 src1 = """
 def func1():
@@ -82,6 +82,52 @@ def testWalk(src: str, expected: List[Tuple[str, str]]) -> None:
     result: List[Tuple[str, str]] = []
     tree = ast.parse(src)
     for node, parent in walk(tree):
+        if 'name' in node.__dict__:
+            parent_repr: str
+            if isinstance(parent, ast.Module):
+                parent_repr = 'ast.Module'
+            elif isinstance(
+                parent, (ast.AsyncFunctionDef, ast.FunctionDef, ast.ClassDef)
+            ):
+                parent_repr = parent.name
+            else:
+                parent_repr = str(type(parent))
+
+            result.append((node.name, parent_repr))
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    'src, expected',
+    [
+        (
+            src1,
+            [
+                ('func1', 'ast.Module'),
+                ('func2', 'ast.Module'),
+                ('func3', 'ast.Module'),
+                ('func3_child1', 'func3'),
+                ('func3_child1_grandchild1', 'func3_child1'),
+                ('func4', 'ast.Module'),
+                ('func4_child1', 'func4'),
+                ('func4_child2', 'func4'),
+                ('func4_child2_grandchild1', 'func4_child2'),
+                ('func5', 'ast.Module'),
+                ('MyClass', 'ast.Module'),
+                ('__init__', 'MyClass'),
+                ('method1', 'MyClass'),
+                ('method1_child1', 'method1'),
+                ('classmethod1', 'MyClass'),
+                ('classmethod1_child1', 'classmethod1'),
+            ],
+        ),
+    ],
+)
+def testWalkDfs(src: str, expected: List[Tuple[str, str]]) -> None:
+    result: List[Tuple[str, str]] = []
+    tree = ast.parse(src)
+    for node, parent in walk_dfs(tree):
         if 'name' in node.__dict__:
             parent_repr: str
             if isinstance(parent, ast.Module):


### PR DESCRIPTION
Closes #158 

Compare any raise statements in function bodies to docstring Raises sections and ensures they match. Exceptions specified in a docstring are kept as a sorted list, so duplicate lines will throw DOC503 as well.

Had to introduce a new walker, `walk.walk_dfs`, but I did add tests for it.

This feature does NOT do any resolution of errors, so something like the following:

```
try:
    1 / 0
except:
    raise
```

will not identify any specific exceptions thrown. Similarly, `except Exception: raise` will expect `Exception` to be included in the docstring. I think both of those cases are already caught as style violations by certain ruff rules (probably under `BLE` or `TRY`?), so it might not be much of a problem.

----

While this checks names of exceptions it doesn't check order(?) like your issue title mentions, but i'm not entirely sure what was meant by that.

Completely open to feedback / changes, let me know if there's anything that could be cleaned up. In particular, there's one bit I don't love: in `visitor.py`, i had to do this to parse a common convention when using rest-style docstrings:

```python
elif doc.style == 'sphinx' and raises.description:
    # :raises: Exception: -> 'Exception'
    splitDesc = raises.description.split(':')
    if len(splitDesc) > 1 and ' ' not in splitDesc[0].strip():
        exc = splitDesc[0].strip()
        docRaises.append(exc)
```

This bit parses docstring lines like `:raises: Exception:`, which seem to be somewhat common in sphinx docstrings but I don't think are technically allowed by the spec[1][2]? `docstring_parser` doesn't currently parse those words into `type_name`. Not sure if this bit of code should be moved into `docstring_parser_fork`, moved into its own function (I wasn't really sure where else to put it), or if you'd prefer to just not support this line format.

- [1] https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
- [2] https://thomas-cokelaer.info/tutorials/sphinx/docstring_python.html