### PR TITLE
fix: get name of a raised exception when bound in except

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [0.5.11] - 2024-12-14
+
+- Fixed
+
+  - Fixed a bug where pydoclint uses variable names instead of the exception
+    itself (https://github.com/jsh9/pydoclint/issues/175)
+
+- Full diff
+  - https://github.com/jsh9/pydoclint/compare/0.5.11...0.5.10
+
 ## [0.5.10] - 2024-12-07
 
 - Changed
@@ -9,8 +19,12 @@
   - Fixed a bug where assigning a value to an attribute caused pydoclint to
     crash
 - Changed
+
   - Renamed function `unparseAnnotation()` into `unparseNode()`
   - Renamed `EdgeCaseError` into `EdgeCaseError`
+
+- Full diff
+  - https://github.com/jsh9/pydoclint/compare/0.5.9...0.5.10
 
 ## [0.5.9] - 2024-09-29
 

--- a/pydoclint/utils/return_yield_raise.py
+++ b/pydoclint/utils/return_yield_raise.py
@@ -140,6 +140,17 @@ def _getRaisedExceptions(
                     ):
                         # case: looks like m.n.exception()
                         yield getFullAttributeName(child.exc.func)
+                    elif (
+                        currentParentExceptHandler
+                        and currentParentExceptHandler.name
+                        and subnode.id == currentParentExceptHandler.name
+                    ):
+                        # case: "except <> as e; raise e" -> we must yield the stuff in <>
+                        # note that if subnode.id != currentParentExceptHandler.name, then the user is raising something not bound by
+                        # this exception handler (meaning we should fall through to yielding the subnode.id)
+                        yield from _extractExceptionsFromExcept(
+                            currentParentExceptHandler
+                        )
                     else:
                         yield subnode.id
 

--- a/pydoclint/utils/return_yield_raise.py
+++ b/pydoclint/utils/return_yield_raise.py
@@ -145,9 +145,13 @@ def _getRaisedExceptions(
                         and currentParentExceptHandler.name
                         and subnode.id == currentParentExceptHandler.name
                     ):
-                        # case: "except <> as e; raise e" -> we must yield the stuff in <>
-                        # note that if subnode.id != currentParentExceptHandler.name, then the user is raising something not bound by
-                        # this exception handler (meaning we should fall through to yielding the subnode.id)
+                        # case: "except <> as e; raise e" -> we must yield the
+                        # stuff in <>
+                        #
+                        # Note: if subnode.id != currentParentExceptHandler.name,
+                        # the user is raising something not bound by
+                        # this exception handler (meaning we should fall
+                        # through to yielding the subnode.id)
                         yield from _extractExceptionsFromExcept(
                             currentParentExceptHandler
                         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoclint
-version = 0.5.10
+version = 0.5.11
 description = A Python docstring linter that checks arguments, returns, yields, and raises sections
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/utils/test_returns_yields_raise.py
+++ b/tests/utils/test_returns_yields_raise.py
@@ -440,6 +440,15 @@ def func15():
         x = 1
     except other.Exception:
         raise
+
+def func16():
+    # ensure that "as e" doesn't mess up getting the name of an exception.
+    try:
+        3 + 3
+    except IOError as e:
+        raise e
+    except (KeyError, IndexError) as e:
+        raise e
 """
 
 
@@ -466,6 +475,7 @@ def testHasRaiseStatements() -> None:
         (117, 0, 'func13'): True,
         (126, 0, 'func14'): True,
         (135, 0, 'func15'): True,
+        (141, 0, 'func16'): True,
     }
 
     assert result == expected
@@ -503,6 +513,7 @@ def testWhichRaiseStatements() -> None:
             'm.n.ValueError',
         ],
         (135, 0, 'func15'): ['other.Exception'],
+        (141, 0, 'func16'): ['IOError', 'IndexError', 'KeyError'],
     }
 
     assert result == expected


### PR DESCRIPTION
When code uses `raise <> as e` and then `raise e`, we previously were incorrectly yielding `e` (the `subnode.id`) rather than determining the originally-bound name of the exception. This introduces an additional check for AST nodes which look like an exception handler with a name binding.

----

closes #175