### PR TITLE
👌 Add pre-commit-hook to run pydoclint via flake8

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
   require_serial: true
 - id: pydoclint-flake8
   name: pydoclint-flake8
-  description: "Run `pydoclint` via `flake8`"
+  description: "Run `pydoclint` as a `flake8` plugin"
   entry: flake8
   args: [--select=DOC]
   language: python

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,12 @@
   language: python
   types: [python]
   require_serial: true
+- id: pydoclint-flake8
+  name: pydoclint-flake8
+  description: "Run `pydoclint` via `flake8`"
+  entry: flake8
+  args: [--select=DOC]
+  language: python
+  types: [python]
+  require_serial: true
+  additional_dependencies: [flake8]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [0.5.16] - 2025-01-11
+
+- Added
+
+  - A pre-commit hook for using _pydoclint_ as a flake8 plugin
+
+- Full diff
+  - https://github.com/jsh9/pydoclint/compare/0.5.15...0.5.16
+
 ## [0.5.15] - 2025-01-10
 
 - Changed

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The corresponding Github repository of _pydoclint_ is:
   - [2.1. As a native command line tool](#21-as-a-native-command-line-tool)
   - [2.2. As a _flake8_ plugin](#22-as-a-flake8-plugin)
   - [2.3. As a pre-commit hook](#23-as-a-pre-commit-hook)
+    - [2.3.1. Native mode](#231-native-mode)
+    - [2.3.2. As a _flake8_ plugin](#232-as-a-flake8-plugin)
   - [2.4. Native vs _flake8_](#24-native-vs-flake8)
   - [2.5. How to configure _pydoclint_](#25-how-to-configure-pydoclint)
   - [2.6. How to ignore certain violations in _flake8_ mode](#26-how-to-ignore-certain-violations-in-flake8-mode)
@@ -95,8 +97,12 @@ other built-in _flake8_ linters on your code.
 
 ### 2.3. As a pre-commit hook
 
-_pydoclint_ is configured for [pre-commit](https://pre-commit.com/) and can be
-set up as a hook with the following `.pre-commit-config.yaml` configuration:
+_pydoclint_ can be use as a [pre-commit hook](https://pre-commit.com/), both in
+the "native" mode or as a _flake8_ plugin.
+
+To use it, put the following in your `.pre-commit-config.yaml` file:
+
+#### 2.3.1. Native mode
 
 ```yaml
 - repo: https://github.com/jsh9/pydoclint
@@ -106,7 +112,18 @@ set up as a hook with the following `.pre-commit-config.yaml` configuration:
       args: [--style=google, --check-return-types=False]
 ```
 
-You will need to install `pre-commit` and run `pre-commit install`.
+(Replace `<latest_tag>` with the latest release tag in
+https://github.com/jsh9/pydoclint/releases)
+
+#### 2.3.2. As a _flake8_ plugin
+
+```yaml
+- repo: https://github.com/jsh9/pydoclint
+  rev: <latest_tag>
+  hooks:
+    - id: pydoclint-flake8
+      args: [--style=google, --check-return-types=False]
+```
 
 ### 2.4. Native vs _flake8_
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,8 @@ The corresponding Github repository of _pydoclint_ is:
   - [2.1. As a native command line tool](#21-as-a-native-command-line-tool)
   - [2.2. As a _flake8_ plugin](#22-as-a-flake8-plugin)
   - [2.3. As a pre-commit hook](#23-as-a-pre-commit-hook)
+    - [2.3.1. Native mode](#231-native-mode)
+    - [2.3.2. As a _flake8_ plugin](#232-as-a-flake8-plugin)
   - [2.4. Native vs _flake8_](#24-native-vs-flake8)
   - [2.5. How to configure _pydoclint_](#25-how-to-configure-pydoclint)
   - [2.6. How to ignore certain violations in _flake8_ mode](#26-how-to-ignore-certain-violations-in-flake8-mode)
@@ -95,8 +97,12 @@ other built-in _flake8_ linters on your code.
 
 ### 2.3. As a pre-commit hook
 
-_pydoclint_ is configured for [pre-commit](https://pre-commit.com/) and can be
-set up as a hook with the following `.pre-commit-config.yaml` configuration:
+_pydoclint_ can be use as a [pre-commit hook](https://pre-commit.com/), both in
+the "native" mode or as a _flake8_ plugin.
+
+To use it, put the following in your `.pre-commit-config.yaml` file:
+
+#### 2.3.1. Native mode
 
 ```yaml
 - repo: https://github.com/jsh9/pydoclint
@@ -106,7 +112,18 @@ set up as a hook with the following `.pre-commit-config.yaml` configuration:
       args: [--style=google, --check-return-types=False]
 ```
 
-You will need to install `pre-commit` and run `pre-commit install`.
+(Replace `<latest_tag>` with the latest release tag in
+https://github.com/jsh9/pydoclint/releases)
+
+#### 2.3.2. As a _flake8_ plugin
+
+```yaml
+- repo: https://github.com/jsh9/pydoclint
+  rev: <latest_tag>
+  hooks:
+    - id: pydoclint-flake8
+      args: [--style=google, --check-return-types=False]
+```
 
 ### 2.4. Native vs _flake8_
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoclint
-version = 0.5.15
+version = 0.5.16
 description = A Python docstring linter that checks arguments, returns, yields, and raises sections
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Since I want the inline ignore feature when running `pydoclint` via `flake8` I'm using a hook like so.
```yaml
  - repo: https://github.com/PyCQA/flake8
    rev: 7.1.1
    hooks:
      - id: flake8
        alias: flake8-docs
        args:
          - "--select=DOC"
          - "--extend-ignore=DOC502,DOC601,DOC603"
          - "--color=always"
          - "--require-return-section-when-returning-nothing=False"
          - "--allow-init-docstring=True"
          - "--skip-checking-short-docstrings=False"
        name: "lint docstrings"
        exclude: "^(docs/|tests?/)"
        additional_dependencies: [pydoclint==0.5.6]
```
This has the obvious drawback that I manually need to look up the latest version of `pydoclint` and update it (If I don't forget the additional dependency, see how outdated it is 😥).

Having a `flake8` based hook in the `pydoclint` repo would allow me to easily keep up with the latest and greatest version.
```yaml
  - repo: https://github.com/jsh9/pydoclint
    rev: <autoupdatable version>
    hooks:
      - id: pydoclint-flake8
        alias: flake8-docs
        args:
          - "--select=DOC"
          - "--extend-ignore=DOC502,DOC601,DOC603"
          - "--color=always"
          - "--require-return-section-when-returning-nothing=False"
          - "--allow-init-docstring=True"
          - "--skip-checking-short-docstrings=False"
        name: "lint docstrings"
        exclude: "^(docs/|tests?/)"
```