### PR TITLE
Fix missing config option onlyAttrsWithClassVarAreTreatedAsClassAttrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change Log
 
-## [Unpublished]
+## [0.6.2] - 2025-02-17
 
 - Fixed
   - An issue where no error was thrown when the user does not supply a path
+  - A bug where `--only-attrs-with-ClassVar-are-treated-as-class-attrs` is not
+    properly passed to the visitor in the flake8 mode
+- Full diff
+  - https://github.com/jsh9/pydoclint/compare/0.6.1...0.6.2
 
 ## [0.6.1] - 2025-02-16
 

--- a/pydoclint/flake8_entry.py
+++ b/pydoclint/flake8_entry.py
@@ -353,6 +353,10 @@ class Plugin:
             '--treat-property-methods-as-class-attributes',
             self.treat_property_methods_as_class_attributes,
         )
+        onlyAttrsWithClassVarAreTreatedAsClassAttrs = self._bool(
+            '--only-attrs-with-ClassVar-are-treated-as-class-attrs',
+            self.only_attrs_with_ClassVar_are_treated_as_class_attrs,
+        )
         shouldDocumentStarArguments = self._bool(
             '--should-document-star-arguments',
             self.should_document_star_arguments,
@@ -389,6 +393,9 @@ class Plugin:
             ),
             treatPropertyMethodsAsClassAttributes=(
                 treatPropertyMethodsAsClassAttributes
+            ),
+            onlyAttrsWithClassVarAreTreatedAsClassAttrs=(
+                onlyAttrsWithClassVarAreTreatedAsClassAttrs
             ),
             shouldDocumentStarArguments=shouldDocumentStarArguments,
             checkStyleMismatch=checkStyleMismatch,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoclint
-version = 0.6.1
+version = 0.6.2
 description = A Python docstring linter that checks arguments, returns, yields, and raises sections
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Fixes https://github.com/jsh9/pydoclint/issues/208