### PR TITLE
Revert `--quiet` to default to `False`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [Unpublished]
+
+- Changed
+  - Reverted the default behavior of `--quiet` to be `False`
+
 ## [0.6.6] - 2025-04-16
 
 - Fixed

--- a/pydoclint/main.py
+++ b/pydoclint/main.py
@@ -49,7 +49,7 @@ def validateStyleValue(
     '-q',
     '--quiet',
     is_flag=True,
-    default=True,
+    default=False,
     help='If True, do not print the file names being checked to the terminal.',
 )
 @click.option(


### PR DESCRIPTION
Fixes https://github.com/jsh9/pydoclint/issues/237.

Reverts the changes in https://github.com/jsh9/pydoclint/pull/236 (which was to address https://github.com/jsh9/pydoclint/issues/233).

