### PR TITLE
Fix output formatting bug with blank lines during redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [0.6.9] - 2025-08-14
+
+- Fixed
+  - Fixed output formatting bug where blank lines between files would appear at
+    the end when redirecting output to a file instead of between each file
+- Full diff
+  - https://github.com/jsh9/pydoclint/compare/0.6.8...0.6.9
+
 ## [0.6.8] - 2025-08-14
 
 - Changed

--- a/pydoclint/main.py
+++ b/pydoclint/main.py
@@ -593,7 +593,7 @@ def main(  # noqa: C901
             counter += 1
             if len(violationsInThisFile) > 0:
                 if counter > 1:
-                    print('')
+                    click.echo('', err=echoAsError)
 
                 if not show_filenames_in_every_violation_message:
                     click.echo(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoclint
-version = 0.6.8
+version = 0.6.9
 description = A Python docstring linter that checks arguments, returns, yields, and raises sections
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Fixes https://github.com/jsh9/pydoclint/issues/234

- Replace print('') with click.echo('', err=echoAsError) to ensure consistent output stream handling between terminal and redirected output
- Bump version to 0.6.9
- Update CHANGELOG.md with fix details

🤖 Generated with [Claude Code](https://claude.ai/code)