### PR TITLE
Support `@property` + `@abstractmethod` without a Returns: section

### DIFF
--- a/docs/violation_codes.md
+++ b/docs/violation_codes.md
@@ -59,8 +59,8 @@ Other potential causes to `DOC103` include:
 | `DOC202` | Function/method has a return section in docstring, but there are no return statements or annotations |
 | `DOC203` | Return type(s) in the docstring not consistent with the return annotation                            |
 
-Note on `DOC201`: Methods with `@property` as its last decorator do not need to
-have a return section.
+Note on `DOC201`: Methods with `@property` as a decorator do not need to have a
+return section.
 
 ## 3. `DOC3xx`: Violations about class docstring and class constructor
 

--- a/pydoclint/utils/special_methods.py
+++ b/pydoclint/utils/special_methods.py
@@ -24,7 +24,7 @@ def checkMethodContainsSpecifiedDecorator(
         and any(
             (  # noqa: PAR001
                 isinstance(_, ast.Name)
-                and hasattr(node.decorator_list[-1], 'id')
+                and hasattr(_, 'id')
                 and _.id == decorator
             )
             for _ in node.decorator_list

--- a/tests/data/common/property_method.py
+++ b/tests/data/common/property_method.py
@@ -1,3 +1,6 @@
+import abc
+
+
 class MyClass:
     data: float = 2.1
 
@@ -10,3 +13,16 @@ class MyClass:
         is a "property method" and is intended to be used as an attribute.
         """
         return self.data
+
+class AbstractClass(abc.ABC):
+    def __init__(self):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def something(self) -> float:
+        """
+        Some abstract property.
+
+        This is also OK; @property does not have to be the inner decorator.
+        """


### PR DESCRIPTION
The [DOC2xx documentation](https://jsh9.github.io/pydoclint/violation_codes.html#2-doc2xx-violations-about-return-arguments) explains that 

> Methods with `@property` as its last decorator do not need to have a return section.

The "last decorator" restriction means this doesn't work for abstract methods, as in

```py
import abc

class C(abc.ABC):
    @property
    @abc.abstractmethod
    def prop(self) -> float:
        """The property.""""
```

.. because `@abstractmethod` can't decorate `@property` (I think because the object returned by `property()` is a native one, so `abstractmethod()` can't tag it with new attributes?).

I couldn't find a reason for that restriction, so this PR removes it. If there is a reason, please let me know - I'll happily put some more time into making this case work.
