### PR TITLE
Docstring parsing errors now produce DOC001 only; no more cascading violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [0.8.5] - 2026-06-02
+
+- Fixed
+  - A bug where malformed docstrings could trigger an internal error when the
+    underlying parser returned an empty parameter name
+  - Avoid cascading downstream violations after `DOC001` parsing errors
+- Full diff
+  - https://github.com/jsh9/pydoclint/compare/0.8.4...0.8.5
+
 ## [0.8.4] - 2026-05-16
 
 - Added

--- a/pydoclint/utils/parse_docstring.py
+++ b/pydoclint/utils/parse_docstring.py
@@ -179,8 +179,22 @@ def parseDocstringInGivenStyle(
     exception: ParseError | None = None
     try:
         doc: Doc = Doc(docstring=docstring, style=style)
+        _validateParsedDoc(doc)
     except ParseError as exc:
         doc = Doc(docstring='', style=style)
         exception = exc
 
     return doc, exception
+
+
+def _validateParsedDoc(doc: Doc) -> None:
+    """
+    Validate parser output before pydoclint converts it into internal args.
+    """
+    for param in doc.parsed.params:
+        if not param.arg_name:
+            raise ParseError('Parsed docstring parameter has an empty name')
+
+    for attr in doc.parsed.attrs:
+        if not attr.arg_name:
+            raise ParseError('Parsed docstring attribute has an empty name')

--- a/pydoclint/utils/visitor_helper.py
+++ b/pydoclint/utils/visitor_helper.py
@@ -10,10 +10,7 @@ if TYPE_CHECKING:
     from pydoclint.utils.return_arg import ReturnArg
     from pydoclint.utils.yield_arg import YieldArg
 
-from docstring_parser import ParseError
-
 from pydoclint.utils.arg import Arg, ArgList
-from pydoclint.utils.doc import Doc
 from pydoclint.utils.edge_case_error import EdgeCaseError
 from pydoclint.utils.generic import (
     appendArgsToCheckToV105,
@@ -22,6 +19,7 @@ from pydoclint.utils.generic import (
     specialEqual,
     stripQuotes,
 )
+from pydoclint.utils.parse_docstring import parseDocstringInGivenStyle
 from pydoclint.utils.special_methods import checkIsPropertyMethod
 from pydoclint.utils.unparser_custom import unparseName
 from pydoclint.utils.violation import Violation
@@ -219,18 +217,20 @@ def getDocumentedAndActualClassArgLists(
         # to determine whether a class needs a docstring.
         return None
 
-    try:
-        doc: Doc = Doc(docstring=classDocstring, style=style)
-    except ParseError as excp:
-        doc = Doc(docstring='', style=style)
+    doc, potentialParsingError = parseDocstringInGivenStyle(
+        docstring=classDocstring,
+        style=style,
+    )
+    if potentialParsingError is not None:
         violations.append(
             Violation(
                 code=1,
                 line=node.lineno,
                 msgPrefix=f'Class `{node.name}`:',
-                msgPostfix=str(excp).replace('\n', ' '),
+                msgPostfix=str(potentialParsingError).replace('\n', ' '),
             )
         )
+        return None
 
     if skipCheckingShortDocstrings and doc.isShortDocstring:
         return None

--- a/pydoclint/visitor.py
+++ b/pydoclint/visitor.py
@@ -4,14 +4,15 @@ import ast
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from docstring_parser import ParseError
+
     from pydoclint.utils.ast_types import FuncOrAsyncFuncDef
+    from pydoclint.utils.doc import Doc
     from pydoclint.utils.return_arg import ReturnArg
     from pydoclint.utils.yield_arg import YieldArg
 
-from docstring_parser import ParseError
 
 from pydoclint.utils.arg import Arg, ArgList
-from pydoclint.utils.doc import Doc
 from pydoclint.utils.edge_case_error import EdgeCaseError
 from pydoclint.utils.generic import (
     buildFuncArgToDefaultMapping,
@@ -260,66 +261,81 @@ class Visitor(ast.NodeVisitor):
                         msgPostfix=msgPostfix,
                     )
                 )
-
-            if styleMismatch:
-                self.violations.append(
-                    Violation(
-                        code=3,
-                        line=node.lineno,
-                        msgPrefix=f'Function/method `{node.name}`:',
-                        msgPostfix=(
-                            f'You specified "{self.style}" style, but the'
-                            f' docstring is likely not written in this style.'
-                        ),
-                    )
-                )
-
-            isShort: bool = doc.isShortDocstring
-            if self.skipCheckingShortDocstrings and isShort:
+                # Parsing failed, so the parsed sections are unreliable.
+                # Report DOC001 only and skip downstream checks.
                 argViolations = []
                 returnViolations = []
                 yieldViolations = []
                 raiseViolations = []
-            else:
-                argViolations = self.checkArguments(
-                    node,
-                    parent_,
-                    doc,
-                    styleMismatch=styleMismatch,
-                )
-                if docstring == '' or styleMismatch:
+            else:  # The docstring parsed cleanly; run the normal checks.
+                if styleMismatch:
+                    self.violations.append(
+                        Violation(
+                            code=3,
+                            line=node.lineno,
+                            msgPrefix=f'Function/method `{node.name}`:',
+                            msgPostfix=(
+                                f'You specified "{self.style}" style, but the'
+                                ' docstring is likely not written in this'
+                                ' style.'
+                            ),
+                        )
+                    )
+
+                isShort: bool = doc.isShortDocstring
+                if self.skipCheckingShortDocstrings and isShort:
+                    argViolations = []
                     returnViolations = []
                     yieldViolations = []
                     raiseViolations = []
-                elif hasYieldStatements(node) and hasReturnStatements(node):
-                    returnViolations = self.checkReturnAndYield(
-                        node, parent_, doc
-                    )
-                    # It doesn't matter what violations fall into which
-                    # list, so we put everything in `returnViolations`
-                    # and then keep `yieldViolations` empty.
-                    yieldViolations = []
-                    if not self.skipCheckingRaises:
-                        raiseViolations = self.checkRaises(node, parent_, doc)
-                    else:
-                        raiseViolations = []
                 else:
-                    returnViolations = self.checkReturns(node, parent_, doc)
-                    yieldViolations = self.checkYields(node, parent_, doc)
-                    if not self.skipCheckingRaises:
-                        raiseViolations = self.checkRaises(node, parent_, doc)
-                    else:
-                        raiseViolations = []
-
-            if isClassConstructor:
-                # Re-check return violations because the rules are
-                # different for class constructors.
-                returnViolations = (
-                    self.checkReturnsAndYieldsInClassConstructor(
-                        parent=parent_,  # type: ignore[arg-type]
-                        doc=doc,
+                    argViolations = self.checkArguments(
+                        node,
+                        parent_,
+                        doc,
+                        styleMismatch=styleMismatch,
                     )
-                )
+                    if docstring == '' or styleMismatch:
+                        returnViolations = []
+                        yieldViolations = []
+                        raiseViolations = []
+                    elif hasYieldStatements(node) and hasReturnStatements(
+                        node
+                    ):
+                        returnViolations = self.checkReturnAndYield(
+                            node, parent_, doc
+                        )
+                        # It doesn't matter what violations fall into which
+                        # list, so we put everything in `returnViolations`
+                        # and then keep `yieldViolations` empty.
+                        yieldViolations = []
+                        if not self.skipCheckingRaises:
+                            raiseViolations = self.checkRaises(
+                                node, parent_, doc
+                            )
+                        else:
+                            raiseViolations = []
+                    else:
+                        returnViolations = self.checkReturns(
+                            node, parent_, doc
+                        )
+                        yieldViolations = self.checkYields(node, parent_, doc)
+                        if not self.skipCheckingRaises:
+                            raiseViolations = self.checkRaises(
+                                node, parent_, doc
+                            )
+                        else:
+                            raiseViolations = []
+
+                if isClassConstructor:
+                    # Re-check return violations because the rules are
+                    # different for class constructors.
+                    returnViolations = (
+                        self.checkReturnsAndYieldsInClassConstructor(
+                            parent=parent_,  # type: ignore[arg-type]
+                            doc=doc,
+                        )
+                    )
 
         self.violations.extend(argViolations)
         self.violations.extend(returnViolations)
@@ -380,31 +396,24 @@ class Visitor(ast.NodeVisitor):
             return classDocstring
 
         # Below: __init__() is allowed to have a separate docstring
-        try:
-            classDoc = Doc(docstring=classDocstring, style=self.style)
-        except ParseError as excp:
-            classDoc = Doc(docstring='', style=self.style)
+        classDoc, classDocParsingError = parseDocstringInGivenStyle(
+            classDocstring,
+            self.style,
+        )
+        if classDocParsingError is not None:
             self.violations.append(
                 Violation(
                     code=1,
                     line=parent_.lineno,
                     msgPrefix=f'Class `{className}`:',
-                    msgPostfix=str(excp).replace('\n', ' '),
+                    msgPostfix=str(classDocParsingError).replace('\n', ' '),
                 )
             )
 
-        try:
-            initDoc = Doc(docstring=initDocstring, style=self.style)
-        except ParseError as excp:
-            initDoc = Doc(docstring='', style=self.style)
-            self.violations.append(
-                Violation(
-                    code=1,
-                    line=node.lineno,
-                    msgPrefix=f'Method `{node.name}`',
-                    msgPostfix=str(excp).replace('\n', ' '),
-                )
-            )
+        initDoc, _ = parseDocstringInGivenStyle(
+            initDocstring,
+            self.style,
+        )
 
         if classDoc.hasReturnsSection:
             self.violations.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
 
 [project]
 name = "pydoclint"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
   "click>=8.1.0",
   "docstring_parser_fork>=0.0.12",

--- a/tests/test_data/google/parsing_errors/cases.py
+++ b/tests/test_data/google/parsing_errors/cases.py
@@ -21,3 +21,85 @@ class A:
             int: The return value
         """
         return 2
+
+
+def test(param: str | None = None,) -> str:
+    """A test function
+
+    Args:
+        :param param: This is just a test
+
+    Returns:
+        str: A string
+    """
+
+    pass
+
+
+def sphinx_type_directive(param: str) -> str:
+    """A test function
+
+    Args:
+        :type param: str
+
+    Returns:
+        str: A string
+    """
+
+    pass
+
+
+def sphinx_param_with_type(param: str) -> str:
+    """A test function
+
+    Args:
+        :param str param: This is just a test
+
+    Returns:
+        str: A string
+    """
+
+    pass
+
+
+def empty_google_arg_name(param: str) -> str:
+    """A test function
+
+    Args:
+        : This is just a test
+
+    Returns:
+        str: A string
+    """
+
+    pass
+
+
+class BadClassDoc:
+    """A test class.
+
+    Args:
+        :param value: This class docstring is malformed.
+    """
+
+    def __init__(self, value: str) -> None:
+        """Initialize the class.
+
+        Args:
+            value (str): A value.
+        """
+
+        self.value = value
+
+
+class BadInitDoc:
+    """A test class."""
+
+    def __init__(self, value: str) -> None:
+        """Initialize the class.
+
+        Args:
+            :param value: This constructor docstring is malformed.
+        """
+
+        self.value = value

--- a/tests/test_data/numpy/parsing_errors/cases.py
+++ b/tests/test_data/numpy/parsing_errors/cases.py
@@ -51,3 +51,85 @@ def funcWithGoogleStyle(arg1: str, arg2: int) -> str:
         str: Return value description
     """
     return arg1
+
+
+def missingParamName(param: str) -> str:
+    """A test function.
+
+    Parameters
+    ----------
+        This has no parameter name.
+
+    Returns
+    -------
+    str
+        A string.
+    """
+
+    pass
+
+
+def malformedRaisesSection(param: str) -> str:
+    """A test function.
+
+    Parameters
+    ----------
+    param : str
+        This is a parameter.
+
+    Raises
+    ------
+        Missing exception type.
+    """
+
+    pass
+
+
+def malformedYieldsSection(param: str) -> str:
+    """A test function.
+
+    Parameters
+    ----------
+    param : str
+        This is a parameter.
+
+    Yields
+    ------
+        Missing yield type.
+    """
+
+    pass
+
+
+class BadClassDoc:
+    """A test class.
+
+    Parameters
+    ----------
+        This has no parameter name.
+    """
+
+    def __init__(self, value) -> None:
+        """Initialize the class.
+
+        Parameters
+        ----------
+        value :
+            A value.
+        """
+
+        self.value = value
+
+
+class BadInitDoc:
+    """A test class."""
+
+    def __init__(self, value: str) -> None:
+        """Initialize the class.
+
+        Parameters
+        ----------
+            This has no parameter name.
+        """
+
+        self.value = value

--- a/tests/test_data/sphinx/parsing_errors/cases.py
+++ b/tests/test_data/sphinx/parsing_errors/cases.py
@@ -1,12 +1,14 @@
 class A:
     """
-    Some class
-
-    param: arg1
-    param: arg2
+    Some class.
     """
 
     def __init__(self):
+        """
+        Do something
+
+        :param: This has no parameter name.
+        """
         pass
 
     def method1(self, arg3: int) -> int:
@@ -19,3 +21,53 @@ class A:
         :rtype: int
         """
         return 2
+
+
+def emptyParamName(param: str) -> str:
+    """A test function.
+
+    :param : This has no parameter name.
+    :return: A string.
+    :rtype: str
+    """
+
+    pass
+
+
+def missingParamDirectiveArgument(param: str) -> str:
+    """A test function.
+
+    :param: This has no parameter name.
+    :return: A string.
+    :rtype: str
+    """
+
+    pass
+
+
+class BadClassDoc:
+    """A test class.
+
+    :param : This class docstring has no parameter name.
+    """
+
+    def __init__(self, value: str) -> None:
+        """Initialize the class.
+
+        :param value: A value.
+        :type value: str
+        """
+
+        self.value = value
+
+
+class BadInitDoc:
+    """A test class."""
+
+    def __init__(self, value: str) -> None:
+        """Initialize the class.
+
+        :param: This constructor docstring has no parameter name.
+        """
+
+        self.value = value

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -979,18 +979,38 @@ def testParsingErrors_google() -> None:
         filename=DATA_DIR / 'google/parsing_errors/cases.py',
         style='google',
         checkStyleMismatch=True,
+        allowInitDocstring=True,
+        checkClassAttributes=False,
     )
+    # When there are parsing errors, only DOC001 is reported for the
+    # malformed docstring; downstream checks are skipped.
     expected = [
-        'DOC001: Class `A`: Potential formatting errors in docstring. Error message: '
-        "Expected a colon in 'arg1'.",
         'DOC001: Function/method `__init__`: Potential formatting errors in '
         "docstring. Error message: Expected a colon in 'arg1'. (Note: DOC001 could "
         'trigger other unrelated violations under this function/method too. Please '
         'fix the docstring formatting first.)',
-        'DOC003: Function/method `__init__`: Docstring style mismatch. (Please read '
-        'more at https://jsh9.github.io/pydoclint/style_mismatch.html ). You '
-        'specified "google" style, but the docstring is likely not written in this '
-        'style.',
+        'DOC001: Function/method `test`: Potential formatting errors in docstring. '
+        'Error message: Parsed docstring parameter has an empty name (Note: DOC001 '
+        'could trigger other unrelated violations under this function/method too. '
+        'Please fix the docstring formatting first.)',
+        'DOC001: Function/method `sphinx_type_directive`: Potential formatting '
+        'errors in docstring. Error message: Parsed docstring parameter has an '
+        'empty name (Note: DOC001 could trigger other unrelated violations under '
+        'this function/method too. Please fix the docstring formatting first.)',
+        'DOC001: Function/method `sphinx_param_with_type`: Potential formatting '
+        'errors in docstring. Error message: Parsed docstring parameter has an '
+        'empty name (Note: DOC001 could trigger other unrelated violations under '
+        'this function/method too. Please fix the docstring formatting first.)',
+        'DOC001: Function/method `empty_google_arg_name`: Potential formatting '
+        'errors in docstring. Error message: Parsed docstring parameter has an '
+        'empty name (Note: DOC001 could trigger other unrelated violations under '
+        'this function/method too. Please fix the docstring formatting first.)',
+        'DOC001: Class `BadClassDoc`: Potential formatting errors in docstring. '
+        'Error message: Parsed docstring parameter has an empty name',
+        'DOC001: Function/method `__init__`: Potential formatting errors in '
+        'docstring. Error message: Parsed docstring parameter has an empty name '
+        '(Note: DOC001 could trigger other unrelated violations under this '
+        'function/method too. Please fix the docstring formatting first.)',
     ]
     assert list(map(str, violations)) == expected
 
@@ -1000,8 +1020,32 @@ def testParsingErrors_sphinx() -> None:
         filename=DATA_DIR / 'sphinx/parsing_errors/cases.py',
         style='sphinx',
         checkStyleMismatch=True,
+        allowInitDocstring=True,
+        checkClassAttributes=False,
     )
-    expected = []  # not sure how to craft docstrings with parsing errors yet
+    # When there are parsing errors, only DOC001 is reported for the
+    # malformed docstring; downstream checks are skipped.
+    expected = [
+        'DOC001: Function/method `__init__`: Potential formatting errors in '
+        'docstring. Error message: Expected one or two arguments for a param '
+        'keyword. (Note: DOC001 could trigger other unrelated violations under this '
+        'function/method too. Please fix the docstring formatting first.)',
+        'DOC001: Function/method `emptyParamName`: Potential formatting errors in '
+        'docstring. Error message: Expected one or two arguments for a param '
+        'keyword. (Note: DOC001 could trigger other unrelated violations under '
+        'this function/method too. Please fix the docstring formatting first.)',
+        'DOC001: Function/method `missingParamDirectiveArgument`: Potential '
+        'formatting errors in docstring. Error message: Expected one or two '
+        'arguments for a param keyword. (Note: DOC001 could trigger other '
+        'unrelated violations under this function/method too. Please fix the '
+        'docstring formatting first.)',
+        'DOC001: Class `BadClassDoc`: Potential formatting errors in docstring. '
+        'Error message: Expected one or two arguments for a param keyword.',
+        'DOC001: Function/method `__init__`: Potential formatting errors in '
+        'docstring. Error message: Expected one or two arguments for a param '
+        'keyword. (Note: DOC001 could trigger other unrelated violations under '
+        'this function/method too. Please fix the docstring formatting first.)',
+    ]
     assert list(map(str, violations)) == expected
 
 
@@ -1012,10 +1056,12 @@ def testParsingErrors_numpy() -> None:
         argTypeHintsInSignature=False,
         style='numpy',
         checkStyleMismatch=True,
+        allowInitDocstring=True,
+        checkClassAttributes=False,
     )
+    # When there are parsing errors, only DOC001 is reported for the
+    # malformed docstring; downstream checks are skipped.
     expected = [
-        'DOC001: Class `A`: Potential formatting errors in docstring. Error message: '
-        "Section 'Parameters' is not empty but nothing was parsed.",
         'DOC001: Function/method `__init__`: Potential formatting errors in '
         "docstring. Error message: Section 'Parameters' is not empty but nothing was "
         'parsed. (Note: DOC001 could trigger other unrelated violations under this '
@@ -1024,16 +1070,31 @@ def testParsingErrors_numpy() -> None:
         "Error message: Section 'Yields' is not empty but nothing was parsed. (Note: "
         'DOC001 could trigger other unrelated violations under this function/method '
         'too. Please fix the docstring formatting first.)',
-        'DOC101: Method `A.method2`: Docstring contains fewer arguments than in '
-        'function signature.',
-        'DOC103: Method `A.method2`: Docstring arguments are different from function '
-        'arguments. (Or could be other formatting issues: '
-        'https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). '
-        'Arguments in the function signature but not in the docstring: [arg4: ].',
         'DOC003: Function/method `funcWithGoogleStyle`: Docstring style mismatch. '
         '(Please read more at https://jsh9.github.io/pydoclint/style_mismatch.html '
         '). You specified "numpy" style, but the docstring is likely not written '
         'in this style.',
+        'DOC001: Function/method `missingParamName`: Potential formatting errors '
+        "in docstring. Error message: Section 'Parameters' is not empty but "
+        'nothing was parsed. (Note: DOC001 could trigger other unrelated '
+        'violations under this function/method too. Please fix the docstring '
+        'formatting first.)',
+        'DOC001: Function/method `malformedRaisesSection`: Potential formatting '
+        "errors in docstring. Error message: Section 'Raises' is not empty but "
+        'nothing was parsed. (Note: DOC001 could trigger other unrelated '
+        'violations under this function/method too. Please fix the docstring '
+        'formatting first.)',
+        'DOC001: Function/method `malformedYieldsSection`: Potential formatting '
+        "errors in docstring. Error message: Section 'Yields' is not empty but "
+        'nothing was parsed. (Note: DOC001 could trigger other unrelated '
+        'violations under this function/method too. Please fix the docstring '
+        'formatting first.)',
+        'DOC001: Class `BadClassDoc`: Potential formatting errors in docstring. '
+        "Error message: Section 'Parameters' is not empty but nothing was parsed.",
+        'DOC001: Function/method `__init__`: Potential formatting errors in '
+        "docstring. Error message: Section 'Parameters' is not empty but nothing "
+        'was parsed. (Note: DOC001 could trigger other unrelated violations under '
+        'this function/method too. Please fix the docstring formatting first.)',
     ]
     assert list(map(str, violations)) == expected
 


### PR DESCRIPTION
Fixes https://github.com/jsh9/pydoclint/issues/285